### PR TITLE
fix: Update Docker Image build and push commands

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,6 +18,7 @@ jobs:
         id: branch
         run: echo "::set-output name=branch::$(echo ${GITHUB_REF#refs/heads/})"
       - name: Build the Docker Image
-        run: docker build -t pos:${{ steps.branch.outputs.branch }} .
+        run: docker build -t pos:latest
+        working-directory: .codesandbox
       - name: Push the Docker image
-        run: docker push pos:${{ steps.branch.outputs.branch }}
+        run: docker push pos:latest


### PR DESCRIPTION
Updated Docker Image build command to use 'pos:latest' tag and removed branch-specific tag from push command.