### PR TITLE
feat: Update Flask and dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
-Flask==2.0.0
-
-Flask-Restful==0.3.9
-
-Werkzeug==2.0.1
-
-flask_sqlalchemy==2.5.2
+Flask==2.2.5
+Werkzeug==2.2.2
+python-barcode==0.13.1
+flask_restful==0.3.9
+flask_sqlalchemy==2.3.2


### PR DESCRIPTION
Update Flask to version 2.2.5, Werkzeug to 2.2.2, and add python-barcode and flask_restful dependencies.